### PR TITLE
Prevent flooding using the input context

### DIFF
--- a/serve.py
+++ b/serve.py
@@ -65,10 +65,10 @@ async def generate(
     stop_sequence: Optional[str] = None,
 ):
     start = time.time()
-    if token_max_length > 2048:
-        return {"text": "Don't abuse the API, please."}
     tokens = tokenizer.encode(context)
     provided_ctx = len(tokens)
+    if token_max_length + provided_ctx > 2048:
+        return {"text": "Don't abuse the API, please."}
     pad_amount = seq - provided_ctx
 
     padded_tokens = np.pad(tokens, ((pad_amount, 0),)).astype(np.uint32)


### PR DESCRIPTION
A simple fix to prevent the flooding of the context input. I think is is why the api is running slow as of this moment. I may have accidently sent a large context slowing it down. :(